### PR TITLE
Fixed scopeName in gohtml to match name in package.json.

### DIFF
--- a/syntaxes/gohtml.tmLanguage
+++ b/syntaxes/gohtml.tmLanguage
@@ -20,7 +20,7 @@
 		</dict>
 	</array>
 	<key>scopeName</key>
-	<string>text.html.gohtml</string>
+	<string>source.gohtml</string>
 	<key>uuid</key>
 	<string>78c486ec-0101-11e2-a85a-00262d996a67</string>
 </dict>


### PR DESCRIPTION
This fixes issue #1 and allows the Go HTML templates to work.
