### PR TITLE
Add yml support

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,18 @@
                     ".gohtml"
                 ],
                 "configuration": "./gotemplate.configuration.json"
+            },
+            {
+                "id": "goyaml",
+                "aliases": [
+                    "Golang YAML Template",
+                    "goyaml"
+                ],
+                "extensions": [
+                    ".yml.tpl",
+                    ".yaml.tpl"
+                ],
+                "configuration": "./gotemplate.configuration.json"
             }
         ],
         "grammars": [
@@ -45,6 +57,11 @@
                 "language": "gohtml",
                 "scopeName": "source.gohtml",
                 "path": "./syntaxes/gohtml.tmLanguage"
+            },
+            {
+                "language": "goyaml",
+                "scopeName": "source.goyaml",
+                "path": "./syntaxes/goyaml.tmLanguage"
             }
         ]
     }

--- a/syntaxes/goyaml.tmLanguage
+++ b/syntaxes/goyaml.tmLanguage
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+		<string>goyaml</string>
+	</array>
+	<key>name</key>
+	<string>GoSublime: YAML</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>include</key>
+			<string>source.yaml</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>source.gotemplate</string>
+		</dict>
+	</array>
+	<key>scopeName</key>
+	<string>source.goyaml</string>
+	<key>uuid</key>
+	<string>78c486ec-0101-11e2-a85a-00262d996a70</string>
+</dict>
+</plist>


### PR DESCRIPTION
The name says it all.
The yml templated by go is used for example for docker-compose.yml files in rancher. See [here](http://rancher.com/docs/rancher/v1.6/en/cli/variable-interpolation/#templating)