### PR TITLE
Improvements

### DIFF
--- a/gotemplate.configuration.json
+++ b/gotemplate.configuration.json
@@ -1,7 +1,7 @@
 {
 	"comments": {
 		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
-		"blockComment": [ "/*", "*/" ]
+		"blockComment": [ "{{/*", "*/}}" ]
 	},
 	// symbols used as brackets
 	"brackets": [

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
                     "gohtml"
                 ],
                 "extensions": [
+                    ".html",
                     ".gohtml"
                 ],
                 "configuration": "./gotemplate.configuration.json"


### PR DESCRIPTION
This adds a couple of small tweaks that I found useful:

* Causes `Ctrl+/` to insert block comments using `{{/*` and `*/}}` (instead of `/*` and `*/`). This is consistent with [Go's definition of a template comment](https://golang.org/pkg/text/template/#hdr-Actions).
* Associates the `gohtml` language with the _.html_ file extension by default.