### PR TITLE
fix extraneous bracket completion

### DIFF
--- a/gotemplate.configuration.json
+++ b/gotemplate.configuration.json
@@ -5,7 +5,6 @@
 	},
 	// symbols used as brackets
 	"brackets": [
-		["{", "}"],
 		["{{", "}}"],
 		["[", "]"],
 		["(", ")"]


### PR DESCRIPTION
without this change i get extra closing brackets when modifying html go templates