### PR TITLE
Add css support

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,6 +133,20 @@
                     ".json.tmpl"
                 ],
                 "configuration": "./gotemplate.configuration.json"
+            },
+            {
+                "id": "gocss",
+                "aliases": [
+                    "Golang css Template",
+                    "gocss"
+                ],
+                "extensions": [
+                    ".css",
+                    ".gocss",
+                    ".css.tmpl",
+                    ".css.tpl"
+                ],
+                "configuration": "./gotemplate.configuration.json"
             }
         ],
         "grammars": [
@@ -180,6 +194,11 @@
                 "language": "gojson",
                 "scopeName": "source.gojson",
                 "path": "./syntaxes/gojson.tmLanguage"
+            },
+            {
+                "language": "gocss",
+                "scopeName": "source.gocss",
+                "path": "./syntaxes/gocss.tmLanguage"
             }
         ]
     }

--- a/syntaxes/gocss.tmLanguage
+++ b/syntaxes/gocss.tmLanguage
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>fileTypes</key>
+	<array>
+		<string>gocss</string>
+	</array>
+	<key>name</key>
+	<string>GoTPL: css</string>
+	<key>patterns</key>
+	<array>
+		<dict>
+			<key>include</key>
+			<string>source.css</string>
+		</dict>
+		<dict>
+			<key>include</key>
+			<string>source.gotemplate</string>
+		</dict>
+	</array>
+	<key>scopeName</key>
+	<string>source.gocss</string>
+	<key>uuid</key>
+	<string>7633844d-6b43-4083-bb54-95a92f8fa0e6</string>
+</dict>
+</plist>


### PR DESCRIPTION
1. I added created a css template syntax at syntaxes/gocss.tmLanguage.  I generated the new UUID with 064590c3-77f7-4f8d-b732-55ab5de0703f.
2. I edited the package.json, adding the new language to /contributes/languages and /contributes/grammars.
3. I tested the plugin with a small html and css template.
   With plugin-free VS Code, I see lines in VSCode's Problems tab for both the html and css files.
   With the current casualjim/gotemplate plugin, the html file displays no problems, but the css file does.
   When I launch the modified extension, I see no lines in the Problems tab.
   The demo code is at https://gist.github.com/jacobpatterson1549/d08b9fb309db17c9177247a02b54e8a5